### PR TITLE
keyboard: led hook and more output functions

### DIFF
--- a/teensy3/usb_dev.c
+++ b/teensy3/usb_dev.c
@@ -604,6 +604,7 @@ static void usb_control(uint32_t stat)
 #ifdef KEYBOARD_INTERFACE
 		if (setup.word1 == 0x02000921 && setup.word2 == ((1<<16)|KEYBOARD_INTERFACE)) {
 			keyboard_leds = buf[0];
+      if(led_callback) led_callback(keyboard_leds);
 			endpoint0_transmit(NULL, 0);
 		}
 #endif

--- a/teensy3/usb_dev.h
+++ b/teensy3/usb_dev.h
@@ -88,6 +88,7 @@ extern uint8_t keyboard_protocol;
 extern uint8_t keyboard_idle_config;
 extern uint8_t keyboard_idle_count;
 extern volatile uint8_t keyboard_leds;
+extern void (*led_callback)(uint8_t keyboard_leds);
 #endif
 
 #ifdef MIDI_INTERFACE

--- a/teensy3/usb_keyboard.h
+++ b/teensy3/usb_keyboard.h
@@ -48,8 +48,21 @@ void usb_keyboard_write_unicode(uint16_t cpoint);
 void usb_keyboard_press_keycode(uint16_t n);
 void usb_keyboard_release_keycode(uint16_t n);
 void usb_keyboard_release_all(void);
+// press oem key 'key' with modifiers 'modifier', and release all other keys
 int usb_keyboard_press(uint8_t key, uint8_t modifier);
+// press oem key 'key' with modifiers 'modifier', do not modify other keys
+// if there are less than 6 keys pressed. Otherwise release the oldest key pressed.
+void usb_keyboard_press_key_raw(uint8_t key, uint8_t modifier);
+// release oem key 'key' with modifiers 'modifier', do not modify other keys.
+void usb_keyboard_release_key_raw(uint8_t key, uint8_t modifier);
+// set keyboard modifiers to 'modifiers'
+void usb_keyboard_set_modifiers(uint8_t modifiers);
+// set keyboard state to 'report' and send it
+void usb_keyboard_send_report(const uint8_t report[8]);
+// send keyboard state report
 int usb_keyboard_send(void);
+// set led state change callback function
+void usb_keyboard_set_led_callback(void (*f)(uint8_t keyboard_leds));
 #ifdef KEYMEDIA_INTERFACE
 void usb_keymedia_release_all(void);
 #endif
@@ -59,6 +72,7 @@ extern uint8_t keyboard_protocol;
 extern uint8_t keyboard_idle_config;
 extern uint8_t keyboard_idle_count;
 extern volatile uint8_t keyboard_leds;
+extern void (*led_callback)(uint8_t keyboard_leds);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- added a function pointer to store a callback function called when a led state change is requested. callback is set with function set_led_callback
- added functions to send oem key presses and releases, usb_keyboard_{press, release}_key_raw, similar to existing static functions usb_keyboard_{press, release}_key. modifiers provided are applied as is by the new functions contrary to the existing ones.
- added usb_keyboard_set_modifiers to change modifiers without any key press/release.
- added function usb_keyboard_send_report to send a modifier and key state over usb.